### PR TITLE
Improve Keyboard Selection

### DIFF
--- a/src/lib/components/TreeItem.svelte
+++ b/src/lib/components/TreeItem.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts" generics="Value" strictEvents>
 	import { keys } from "$lib/helpers/keys.js";
-	import { isCmdOrCtrlKey } from "$lib/helpers/platform.js";
+	import { isMac } from "$lib/helpers/platform.js";
 	import type { TreeNode } from "$lib/helpers/tree.js";
 	import { getContext, setContext } from "svelte";
 	import type { HTMLAttributes } from "svelte/elements";
@@ -108,6 +108,16 @@
 		return getItemElement(node);
 	}
 
+	function isCtrlKey(event: KeyboardEvent | PointerEvent) {
+		if (isMac()) {
+			// "Ctrl + Up/Down/Space" are default OS shortcuts.
+			// "Command + Space" is the default shortcut for Spotlight.
+			// Use the Option key as an alternative.
+			return event.altKey;
+		}
+		return event.ctrlKey;
+	}
+
 	type HTMLElementEvent<Event> = Event & { currentTarget: HTMLElement };
 
 	function handleKeyDown(event: HTMLElementEvent<KeyboardEvent>) {
@@ -153,7 +163,9 @@
 				handlePageUpOrDownKey(event);
 				break;
 			}
-			case keys.SPACE: {
+			// "Alt + Space" inserts a non-breaking space.
+			case keys.SPACE:
+			case keys.NON_BREAKING_SPACE: {
 				selectedIds.toggle(item.id);
 				break;
 			}
@@ -177,7 +189,9 @@
 
 		if (event.shiftKey) {
 			$clearSelectionOnBlur = false;
-		} else if (isCmdOrCtrlKey(event)) {
+		}
+
+		if (isCtrlKey(event)) {
 			$clearSelectionOnBlur = false;
 			$selectOnFocus = false;
 		}
@@ -221,7 +235,7 @@
 			return;
 		}
 
-		if (isCmdOrCtrlKey(event)) {
+		if (isCtrlKey(event)) {
 			$clearSelectionOnBlur = false;
 			selectedIds.toggle(item.id);
 		}

--- a/src/lib/components/TreeView.svelte
+++ b/src/lib/components/TreeView.svelte
@@ -6,6 +6,7 @@
 		items: Readable<TreeNode<unknown>[]>;
 		focusableId: Writable<string | null>;
 		clearSelectionOnBlur: Writable<boolean>;
+		selectOnFocus: Writable<boolean>;
 	};
 
 	const contextKey = Symbol();
@@ -56,6 +57,7 @@
 		items: writable(items),
 		focusableId: writable(null),
 		clearSelectionOnBlur: writable(true),
+		selectOnFocus: writable(true),
 	} satisfies TreeContext;
 
 	$: context.expandedIds.set(expandedIds);

--- a/src/lib/helpers/keys.ts
+++ b/src/lib/helpers/keys.ts
@@ -8,4 +8,5 @@ export const keys = {
 	PAGE_UP: "PageUp",
 	PAGE_DOWN: "PageDown",
 	SPACE: " ",
+	NON_BREAKING_SPACE: "\u00A0",
 } as const;

--- a/src/lib/helpers/keys.ts
+++ b/src/lib/helpers/keys.ts
@@ -7,4 +7,5 @@ export const keys = {
 	END: "End",
 	PAGE_UP: "PageUp",
 	PAGE_DOWN: "PageDown",
+	SPACE: " ",
 } as const;

--- a/src/lib/helpers/platform.ts
+++ b/src/lib/helpers/platform.ts
@@ -6,6 +6,19 @@ export function getPlatform() {
 	return navigator.platform;
 }
 
+/**
+ * Returns `true` if the platform is macOS, otherwise `false`.
+ */
 export function isMac() {
 	return /mac/i.test(getPlatform());
+}
+
+/**
+ * If the platform is macOS, returns `event.metaKey`,
+ * otherwise, returns `event.ctrlKey`.
+ */
+export function isCmdOrCtrlKey(
+	event: KeyboardEvent | PointerEvent | MouseEvent,
+) {
+	return isMac() ? event.metaKey : event.ctrlKey;
 }

--- a/src/lib/helpers/platform.ts
+++ b/src/lib/helpers/platform.ts
@@ -12,13 +12,3 @@ export function getPlatform() {
 export function isMac() {
 	return /mac/i.test(getPlatform());
 }
-
-/**
- * If the platform is macOS, returns `event.metaKey`,
- * otherwise, returns `event.ctrlKey`.
- */
-export function isCmdOrCtrlKey(
-	event: KeyboardEvent | PointerEvent | MouseEvent,
-) {
-	return isMac() ? event.metaKey : event.ctrlKey;
-}


### PR DESCRIPTION
Add the ability to select non-contiguous nodes using the keyboard.

`Space` Toggles selection

On Windows and Linux:
- `Ctrl + ↑` Moves backwards without affecting selection
- `Ctrl + ↓` Moves forward without affecting selection

On macOS, `Ctrl + ↑/↓` are default OS shortcuts. `⌘ + Space` opens spotlight, so you can't toggle selection without first releasing the `⌘` key. The best alternative to `Ctrl` is the `⌥` key.