### PR TITLE
Support Custom Metadata

### DIFF
--- a/packages/svelte-file-tree-styled/src/lib/components/StyledTree.svelte
+++ b/packages/svelte-file-tree-styled/src/lib/components/StyledTree.svelte
@@ -96,7 +96,7 @@
 				}
 
 				for (const child of item.node.children) {
-					if (child.name === name) {
+					if (child.data.name === name) {
 						onAlreadyExistsError?.({ name });
 						return false;
 					}
@@ -107,14 +107,14 @@
 					case "file": {
 						node = new FileNode({
 							id: crypto.randomUUID(),
-							name,
+							data: { name },
 						});
 						break;
 					}
 					case "folder": {
 						node = new FolderNode({
 							id: crypto.randomUUID(),
-							name,
+							data: { name },
 							children: [],
 						});
 						break;

--- a/packages/svelte-file-tree-styled/src/lib/components/StyledTreeItem.svelte
+++ b/packages/svelte-file-tree-styled/src/lib/components/StyledTreeItem.svelte
@@ -85,7 +85,7 @@
 		{#if editing}
 			<TreeItemInput class="border bg-white focus:outline-none" />
 		{:else}
-			<span class="select-none">{item.node.name}</span>
+			<span class="select-none">{item.node.data.name}</span>
 		{/if}
 	</TreeItem>
 </TreeContextMenu>

--- a/packages/svelte-file-tree/src/lib/components/Tree/Tree.svelte
+++ b/packages/svelte-file-tree/src/lib/components/Tree/Tree.svelte
@@ -1,4 +1,5 @@
-<script lang="ts">
+<script lang="ts" generics="TData extends FileTreeNodeData">
+	import type { FileTreeNodeData } from "$lib/tree.svelte.js";
 	import { SvelteSet } from "svelte/reactivity";
 	import TreeItemProvider from "./TreeItemProvider.svelte";
 	import { createTreeState } from "./state.svelte.js";
@@ -21,7 +22,7 @@
 		ref = $bindable(null),
 		generateCopyId = () => crypto.randomUUID(),
 		onRenameItem = ({ target, name }) => {
-			target.name = name;
+			target.data.name = name;
 			return true;
 		},
 		onMoveItems = ({ updates }) => {
@@ -44,7 +45,7 @@
 		onAlreadyExistsError,
 		onCircularReferenceError,
 		...rest
-	}: TreeProps = $props();
+	}: TreeProps<TData> = $props();
 
 	const treeState = createTreeState({
 		tree: () => tree,

--- a/packages/svelte-file-tree/src/lib/components/Tree/TreeItemProvider.svelte
+++ b/packages/svelte-file-tree/src/lib/components/Tree/TreeItemProvider.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" module>
+	import type { FileTreeNodeData } from "$lib/tree.svelte.js";
 	import { DEV } from "esm-env";
 	import { getContext, hasContext, setContext, type Snippet } from "svelte";
 	import type { TreeState } from "./state.svelte.js";
@@ -6,9 +7,9 @@
 
 	const CONTEXT_KEY = Symbol("TreeItemProvider");
 
-	export type TreeItemProviderContext = {
-		treeState: TreeState;
-		item: () => TreeItemState;
+	export type TreeItemProviderContext<TData extends FileTreeNodeData = FileTreeNodeData> = {
+		treeState: TreeState<TData>;
+		item: () => TreeItemState<TData>;
 	};
 
 	export function getTreeItemProviderContext(): TreeItemProviderContext {
@@ -18,27 +19,24 @@
 
 		return getContext(CONTEXT_KEY);
 	}
-
-	function setTreeItemProviderContext(context: TreeItemProviderContext): void {
-		setContext(CONTEXT_KEY, context);
-	}
 </script>
 
-<script lang="ts">
+<script lang="ts" generics="TData extends FileTreeNodeData">
 	const {
 		treeState,
 		item,
 		children,
 	}: {
-		treeState: TreeState;
-		item: TreeItemState;
+		treeState: TreeState<TData>;
+		item: TreeItemState<TData>;
 		children: Snippet;
 	} = $props();
 
-	setTreeItemProviderContext({
+	const context: TreeItemProviderContext<TData> = {
 		treeState,
 		item: () => item,
-	});
+	};
+	setContext(CONTEXT_KEY, context);
 
 	$effect(() => {
 		return () => {

--- a/packages/svelte-file-tree/src/lib/components/Tree/types.ts
+++ b/packages/svelte-file-tree/src/lib/components/Tree/types.ts
@@ -1,12 +1,15 @@
 import type { HTMLDivAttributes, MaybePromise } from "$lib/internal/types.js";
-import type { FileTree, FileTreeNode, FolderNode } from "$lib/tree.svelte.js";
+import type { FileTree, FileTreeNode, FileTreeNodeData, FolderNode } from "$lib/tree.svelte.js";
 import type { Snippet } from "svelte";
 import type { SvelteSet } from "svelte/reactivity";
 
-export type TreeItemState<TNode extends FileTreeNode = FileTreeNode> = {
+export type TreeItemState<
+	TData extends FileTreeNodeData = FileTreeNodeData,
+	TNode extends FileTreeNode<TData> = FileTreeNode<TData>,
+> = {
 	node: TNode;
 	index: number;
-	parent?: TreeItemState<FolderNode>;
+	parent?: TreeItemState<TData, FolderNode<TData>>;
 	depth: number;
 	selected: () => boolean;
 	expanded: () => boolean;
@@ -19,8 +22,8 @@ export type TreeItemState<TNode extends FileTreeNode = FileTreeNode> = {
 
 export type DropPosition = "before" | "after" | "inside";
 
-export type TreeItemSnippetArgs = {
-	item: TreeItemState;
+export type TreeItemSnippetArgs<TData extends FileTreeNodeData = FileTreeNodeData> = {
+	item: TreeItemState<TData>;
 	rename: (name: string) => Promise<boolean>;
 	paste: (position?: DropPosition) => Promise<boolean>;
 	remove: () => Promise<boolean>;
@@ -28,32 +31,32 @@ export type TreeItemSnippetArgs = {
 
 export type PasteOperation = "copy" | "cut";
 
-export type RenameItemArgs = {
-	target: FileTreeNode;
+export type RenameItemArgs<TData extends FileTreeNodeData = FileTreeNodeData> = {
+	target: FileTreeNode<TData>;
 	name: string;
 };
 
-export type MoveItemsArgs = {
+export type MoveItemsArgs<TData extends FileTreeNodeData = FileTreeNodeData> = {
 	updates: Array<{
-		target: FolderNode | FileTree;
-		children: Array<FileTreeNode>;
+		target: FolderNode<TData> | FileTree<TData>;
+		children: Array<FileTreeNode<TData>>;
 	}>;
-	moved: Array<FileTreeNode>;
+	moved: Array<FileTreeNode<TData>>;
 };
 
-export type CopyPasteItemsArgs = {
-	target: FolderNode | FileTree;
+export type CopyPasteItemsArgs<TData extends FileTreeNodeData = FileTreeNodeData> = {
+	target: FolderNode<TData> | FileTree<TData>;
 	start: number;
-	copies: Array<FileTreeNode>;
-	originals: Array<FileTreeNode>;
+	copies: Array<FileTreeNode<TData>>;
+	originals: Array<FileTreeNode<TData>>;
 };
 
-export type RemoveItemsArgs = {
+export type RemoveItemsArgs<TData extends FileTreeNodeData = FileTreeNodeData> = {
 	updates: Array<{
-		target: FolderNode | FileTree;
-		children: Array<FileTreeNode>;
+		target: FolderNode<TData> | FileTree<TData>;
+		children: Array<FileTreeNode<TData>>;
 	}>;
-	removed: Array<FileTreeNode>;
+	removed: Array<FileTreeNode<TData>>;
 };
 
 export type ResolveNameConflictArgs = {
@@ -67,15 +70,15 @@ export type AlreadyExistsErrorArgs = {
 	name: string;
 };
 
-export type CircularReferenceErrorArgs = {
-	target: FileTreeNode;
+export type CircularReferenceErrorArgs<TData extends FileTreeNodeData = FileTreeNodeData> = {
+	target: FileTreeNode<TData>;
 	position: DropPosition;
 };
 
-export interface TreeProps
+export interface TreeProps<TData extends FileTreeNodeData = FileTreeNodeData>
 	extends Omit<HTMLDivAttributes, "children" | "role" | "aria-multiselectable"> {
-	tree: FileTree;
-	item: Snippet<[args: TreeItemSnippetArgs]>;
+	tree: FileTree<TData>;
+	item: Snippet<[args: TreeItemSnippetArgs<TData>]>;
 	defaultSelectedIds?: Iterable<string>;
 	selectedIds?: SvelteSet<string>;
 	defaultExpandedIds?: Iterable<string>;
@@ -83,16 +86,16 @@ export interface TreeProps
 	defaultClipboardIds?: Iterable<string>;
 	clipboardIds?: SvelteSet<string>;
 	pasteOperation?: PasteOperation;
-	isItemEditable?: boolean | ((node: FileTreeNode) => boolean);
-	isItemDisabled?: boolean | ((node: FileTreeNode) => boolean);
+	isItemEditable?: boolean | ((node: FileTreeNode<TData>) => boolean);
+	isItemDisabled?: boolean | ((node: FileTreeNode<TData>) => boolean);
 	id?: string;
 	ref?: HTMLElement | null;
 	generateCopyId?: () => string;
-	onRenameItem?: (args: RenameItemArgs) => MaybePromise<boolean>;
-	onMoveItems?: (args: MoveItemsArgs) => MaybePromise<boolean>;
-	onCopyPasteItems?: (args: CopyPasteItemsArgs) => MaybePromise<boolean>;
-	onRemoveItems?: (args: RemoveItemsArgs) => MaybePromise<boolean>;
+	onRenameItem?: (args: RenameItemArgs<TData>) => MaybePromise<boolean>;
+	onMoveItems?: (args: MoveItemsArgs<TData>) => MaybePromise<boolean>;
+	onCopyPasteItems?: (args: CopyPasteItemsArgs<TData>) => MaybePromise<boolean>;
+	onRemoveItems?: (args: RemoveItemsArgs<TData>) => MaybePromise<boolean>;
 	onResolveNameConflict?: (args: ResolveNameConflictArgs) => MaybePromise<NameConflictResolution>;
 	onAlreadyExistsError?: (args: AlreadyExistsErrorArgs) => void;
-	onCircularReferenceError?: (args: CircularReferenceErrorArgs) => void;
+	onCircularReferenceError?: (args: CircularReferenceErrorArgs<TData>) => void;
 }

--- a/packages/svelte-file-tree/src/lib/components/TreeItem/TreeItem.svelte
+++ b/packages/svelte-file-tree/src/lib/components/TreeItem/TreeItem.svelte
@@ -21,10 +21,6 @@
 
 		return getContext(CONTEXT_KEY);
 	}
-
-	function setTreeItemContext(context: TreeItemContext): void {
-		setContext(CONTEXT_KEY, context);
-	}
 </script>
 
 <script lang="ts">
@@ -53,11 +49,12 @@
 			item,
 		});
 
-	setTreeItemContext({
+	const context: TreeItemContext = {
 		setEditing: (value) => {
 			editing = value;
 		},
-	});
+	};
+	setContext(CONTEXT_KEY, context);
 
 	const handleFocusIn: EventHandler<FocusEvent, HTMLElement> = () => {
 		treeState.setTabbableId(item().node.id);

--- a/packages/svelte-file-tree/src/lib/components/TreeItemInput/TreeItemInput.svelte
+++ b/packages/svelte-file-tree/src/lib/components/TreeItemInput/TreeItemInput.svelte
@@ -10,7 +10,7 @@
 	const { setEditing } = getTreeItemContext();
 
 	let {
-		name = $bindable(item().node.name),
+		name = $bindable(item().node.data.name),
 		ref = $bindable(null),
 		onkeydown,
 		onblur,

--- a/packages/svelte-file-tree/src/lib/tree.svelte.ts
+++ b/packages/svelte-file-tree/src/lib/tree.svelte.ts
@@ -1,88 +1,52 @@
-export type FileTreeNode = FileNode | FolderNode;
-
-export type FileTreeNodeJSON = FileNodeJSON | FolderNodeJSON;
-
-export type FileTreeJSON = {
-	children: Array<FileTreeNodeJSON>;
+export type FileTreeNodeData = {
+	name: string;
 };
 
-export class FileTree {
-	children: Array<FileTreeNode> = $state([]);
+export type FileTreeNode<TData extends FileTreeNodeData = FileTreeNodeData> =
+	| FileNode<TData>
+	| FolderNode<TData>;
 
-	constructor(children: Array<FileTreeNode>) {
+export class FileTree<TData extends FileTreeNodeData = FileTreeNodeData> {
+	children: Array<FileTreeNode<TData>> = $state([]);
+
+	constructor(children: Array<FileTreeNode<TData>>) {
 		this.children = children;
-	}
-
-	toJSON(): FileTreeJSON {
-		return {
-			children: this.children.map((child) => child.toJSON()),
-		};
 	}
 }
 
-export type FileNodeProps = {
+export type FileNodeProps<TData extends FileTreeNodeData = FileTreeNodeData> = {
 	id: string;
-	name: string;
+	data: TData;
 };
 
-export type FileNodeJSON = {
-	type: "file";
-	id: string;
-	name: string;
-};
-
-export class FileNode {
+export class FileNode<TData extends FileTreeNodeData = FileTreeNodeData> {
 	readonly id: string;
-	name = $state.raw("");
+	data: TData = $state({} as TData);
 
-	constructor({ id, name }: FileNodeProps) {
+	constructor({ id, data }: FileNodeProps<TData>) {
 		this.id = id;
-		this.name = name;
+		this.data = data;
 	}
 
 	readonly type = "file";
-
-	toJSON(): FileNodeJSON {
-		return {
-			type: "file",
-			id: this.id,
-			name: this.name,
-		};
-	}
 }
 
-export type FolderNodeProps = {
+export type FolderNodeProps<TData extends FileTreeNodeData = FileTreeNodeData> = {
 	id: string;
-	name: string;
-	children: Array<FileTreeNode>;
+	data: TData;
+	children: Array<FileTreeNode<TData>>;
 };
 
-export type FolderNodeJSON = {
-	type: "folder";
-	id: string;
-	name: string;
-	children: Array<FileTreeNodeJSON>;
-};
-
-export class FolderNode {
+export class FolderNode<TData extends FileTreeNodeData = FileTreeNodeData> {
 	readonly id: string;
-	name = $state.raw("");
-	children: Array<FileTreeNode> = $state([]);
+	data: TData = $state({} as TData);
+	children: Array<FileTreeNode<TData>> = $state([]);
 
-	constructor({ id, name, children }: FolderNodeProps) {
+	constructor({ id, data, children }: FolderNodeProps<TData>) {
 		this.id = id;
-		this.name = name;
+		this.data = data;
 		this.children = children;
 	}
 
 	readonly type = "folder";
-
-	toJSON(): FolderNodeJSON {
-		return {
-			type: "folder",
-			id: this.id,
-			name: this.name,
-			children: this.children.map((child) => child.toJSON()),
-		};
-	}
 }

--- a/sites/preview/src/routes/+page.svelte
+++ b/sites/preview/src/routes/+page.svelte
@@ -12,41 +12,59 @@
 	const tree = new FileTree([
 		new FolderNode({
 			id: "0",
-			name: "Documents",
+			data: {
+				name: "Documents",
+			},
 			children: [
 				new FolderNode({
 					id: "1",
-					name: "Work",
+					data: {
+						name: "Work",
+					},
 					children: [
 						new FolderNode({
 							id: "2",
-							name: "Projects",
+							data: {
+								name: "Projects",
+							},
 							children: [
 								new FileNode({
 									id: "3",
-									name: "project_a.md",
+									data: {
+										name: "project_a.md",
+									},
 								}),
 								new FileNode({
 									id: "4",
-									name: "project_b.md",
+									data: {
+										name: "project_b.md",
+									},
 								}),
 							],
 						}),
 						new FileNode({
 							id: "5",
-							name: "q4_report.docx",
+							data: {
+								name: "q4_report.docx",
+							},
 						}),
 						new FolderNode({
 							id: "6",
-							name: "Meetings",
+							data: {
+								name: "Meetings",
+							},
 							children: [
 								new FileNode({
 									id: "7",
-									name: "meeting_minutes.txt",
+									data: {
+										name: "meeting_minutes.txt",
+									},
 								}),
 								new FileNode({
 									id: "8",
-									name: "schedule.pdf",
+									data: {
+										name: "schedule.pdf",
+									},
 								}),
 							],
 						}),
@@ -54,61 +72,85 @@
 				}),
 				new FolderNode({
 					id: "9",
-					name: "Personal",
+					data: {
+						name: "Personal",
+					},
 					children: [
 						new FolderNode({
 							id: "10",
-							name: "Recipes",
+							data: {
+								name: "Recipes",
+							},
 							children: [
 								new FileNode({
 									id: "11",
-									name: "pasta.txt",
+									data: {
+										name: "pasta.txt",
+									},
 								}),
 								new FileNode({
 									id: "12",
-									name: "cookies.txt",
+									data: {
+										name: "cookies.txt",
+									},
 								}),
 							],
 						}),
 						new FileNode({
 							id: "13",
-							name: "taxes_2023.pdf",
+							data: {
+								name: "taxes_2023.pdf",
+							},
 						}),
 					],
 				}),
 				new FileNode({
 					id: "14",
-					name: "resume.pdf",
+					data: {
+						name: "resume.pdf",
+					},
 				}),
 			],
 		}),
 		new FolderNode({
 			id: "15",
-			name: "Pictures",
+			data: {
+				name: "Pictures",
+			},
 			children: [
 				new FolderNode({
 					id: "16",
-					name: "Vacation",
+					data: {
+						name: "Vacation",
+					},
 					children: [
 						new FileNode({
 							id: "17",
-							name: "beach.jpg",
+							data: {
+								name: "beach.jpg",
+							},
 						}),
 						new FileNode({
 							id: "18",
-							name: "mountain.jpg",
+							data: {
+								name: "mountain.jpg",
+							},
 						}),
 					],
 				}),
 				new FileNode({
 					id: "19",
-					name: "profile.jpg",
+					data: {
+						name: "profile.jpg",
+					},
 				}),
 			],
 		}),
 		new FileNode({
 			id: "20",
-			name: "notes.txt",
+			data: {
+				name: "notes.txt",
+			},
 		}),
 	]);
 
@@ -117,7 +159,7 @@
 	}
 
 	function handleCircularReferenceError({ target, position }: CircularReferenceErrorArgs): void {
-		toast.error(`Cannot move "${target.name}" ${position} itself`);
+		toast.error(`Cannot move "${target.data.name}" ${position} itself`);
 	}
 </script>
 


### PR DESCRIPTION
The `FileNode` and `FolderNode` classes only store the `name`. This is annoying in case you have other metadata like `createdAt`.

The classes were modified to accept a `data` object instead with at least a `name` property.
```ts
// previously
const file = new FileNode({
  id: "0",
  name: "image.jpg",
});

// now
const file = new FileNode({
  id: "0",
  data: {
    name: "image.jpg",
  },
});
```