### PR TITLE
fix: cleanup deleted items correctly

### DIFF
--- a/packages/svelte-file-tree/src/lib/components/Tree/state.svelte.ts
+++ b/packages/svelte-file-tree/src/lib/components/Tree/state.svelte.ts
@@ -718,6 +718,10 @@ export function createTreeState<TData extends FileTreeNodeData>({
 		selectedIds().delete(id);
 		expandedIds().delete(id);
 		clipboardIds().delete(id);
+
+		if (clipboardIds().size === 0) {
+			setPasteOperation(undefined);
+		}
 	}
 
 	function onItemDestroyed(id: string): void {


### PR DESCRIPTION
`pasteOperation` should be set to `undefined` when all the items in the clipboard are deleted