### PR TITLE
fix: consider cildren of dragged items dragged

### DIFF
--- a/packages/svelte-file-tree/src/lib/components/state.svelte.ts
+++ b/packages/svelte-file-tree/src/lib/components/state.svelte.ts
@@ -67,7 +67,7 @@ class TreeItemStateImpl<TNode extends FileNode | FolderNode<TNode> = FileTreeNod
 	readonly inClipboard: boolean = $derived.by(() => this.clipboardIds().has(this.node.id));
 
 	readonly disabled: boolean = $derived.by(() => {
-		if (this.parent?.disabled === true) {
+		if (this.parent?.disabled) {
 			return true;
 		}
 
@@ -83,15 +83,15 @@ class TreeItemStateImpl<TNode extends FileNode | FolderNode<TNode> = FileTreeNod
 	});
 
 	readonly dragged: boolean = $derived.by(() => {
+		if (this.parent?.dragged) {
+			return true;
+		}
+
 		if (this.draggedId() === undefined) {
 			return false;
 		}
 
-		if (this.draggedId() === this.node.id) {
-			return true;
-		}
-
-		return this.selected && this.parent?.dragged !== true;
+		return this.draggedId() === this.node.id || this.selected;
 	});
 }
 


### PR DESCRIPTION
Before:
<img width="1399" alt="Screenshot 2025-04-07 at 3 26 27 PM" src="https://github.com/user-attachments/assets/b2e5c853-a772-4214-b94c-ef3e2671db41" />

After:
<img width="1399" alt="Screenshot 2025-04-07 at 3 24 27 PM" src="https://github.com/user-attachments/assets/d16734c6-dee8-4db6-b2a2-4df7bbce2a2e" />
