### PR TITLE
feat: file dnd

### DIFF
--- a/.changeset/plain-books-eat.md
+++ b/.changeset/plain-books-eat.md
@@ -1,0 +1,6 @@
+---
+"svelte-file-tree": minor
+---
+
+
+breaking: rework drag and drop callbacks (https://github.com/abdel-17/svelte-file-tree/pull/70)

--- a/packages/svelte-file-tree/src/lib/components/TreeItem.svelte
+++ b/packages/svelte-file-tree/src/lib/components/TreeItem.svelte
@@ -1,34 +1,33 @@
 <script
 	lang="ts"
-	generics="TFile extends FileNode = FileNode, TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>"
+	generics="TFile extends FileNode = FileNode, TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>, TTree extends FileTree<TFile | TFolder> = FileTree<TFile | TFolder>"
 >
 	import {
 		draggable,
 		dropTargetForElements,
 	} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+	import { dropTargetForExternal } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 	import type { EventHandler } from "svelte/elements";
 	import { composeEventHandlers, noop } from "$lib/helpers.js";
-	import type { DefaultTFolder, FileNode, FolderNode } from "$lib/tree.svelte.js";
+	import type { DefaultTFolder, FileNode, FileTree, FolderNode } from "$lib/tree.svelte.js";
 	import { getTreeContext } from "./context.js";
 	import type { TreeItemProps } from "./types.js";
 
-	const context = getTreeContext<TFile, TFolder>();
+	const context = getTreeContext<TFile, TFolder, TTree>();
 
 	let {
 		children,
 		item,
 		ref = $bindable(null),
-		onDragStart = noop,
-		onDragEnd = noop,
 		onDragEnter = noop,
-		onDragOver = noop,
 		onDragLeave = noop,
+		onDrag = noop,
 		onDrop = noop,
 		onfocusin,
 		onkeydown,
 		onclick,
 		...rest
-	}: TreeItemProps<TFile, TFolder> = $props();
+	}: TreeItemProps<TFile, TFolder, TTree> = $props();
 
 	const handleFocusIn: EventHandler<FocusEvent, HTMLDivElement> = (event) => {
 		context.onFocusIn(item, event);
@@ -45,26 +44,10 @@
 	$effect(() => {
 		return draggable({
 			element: ref!,
-			getInitialData: () => ({ id: item.node.id }),
+			getInitialData: () => context.getDragData(item.node.id),
 			canDrag: (args) => context.canDrag(item, args),
 			onDragStart: (args) => {
 				context.onDragStart(item, args);
-				onDragStart({
-					input: args.location.current.input,
-					source: {
-						id: item.node.id,
-						element: args.source.element,
-					},
-				});
-			},
-			onDrop: (args) => {
-				onDragEnd({
-					input: args.location.current.input,
-					source: {
-						id: item.node.id,
-						element: args.source.element,
-					},
-				});
 			},
 		});
 	});
@@ -72,80 +55,106 @@
 	$effect(() => {
 		return dropTargetForElements({
 			element: ref!,
-			getData: () => ({ id: item.node.id }),
-			canDrop: (args) => {
-				const canDrop = context.canDrop(item, args);
-				Object.defineProperty(args.input, "__canDrop", {
-					value: canDrop,
-					configurable: true,
-				});
-				return canDrop;
-			},
+			getData: () => context.getDragData(item.node.id),
+			canDrop: (args) => context.canDrop(item, args),
 			onDragEnter: (args) => {
-				const source = args.source;
-				const sourceId = source.data.id;
-				if (typeof sourceId !== "string") {
+				const source = context.getItemFromDragData(args.source.data);
+				if (source === undefined) {
 					return;
 				}
 
 				onDragEnter({
+					type: "item",
 					input: args.location.current.input,
-					source: {
-						id: sourceId,
-						element: source.element,
-					},
-				});
-			},
-			onDrag: (args) => {
-				const source = args.source;
-				const sourceId = source.data.id;
-				if (typeof sourceId !== "string") {
-					return;
-				}
-
-				onDragOver({
-					input: args.location.current.input,
-					source: {
-						id: sourceId,
-						element: source.element,
-					},
+					source,
+					destination: context.getDropDestination(item),
 				});
 			},
 			onDragLeave: (args) => {
-				const source = args.source;
-				const sourceId = source.data.id;
-				if (typeof sourceId !== "string") {
+				const source = context.getItemFromDragData(args.source.data);
+				if (source === undefined) {
 					return;
 				}
 
 				onDragLeave({
+					type: "item",
 					input: args.location.current.input,
-					source: {
-						id: sourceId,
-						element: source.element,
-					},
+					source,
+					destination: context.getDropDestination(item),
+				});
+			},
+			onDrag: (args) => {
+				const source = context.getItemFromDragData(args.source.data);
+				if (source === undefined) {
+					return;
+				}
+
+				onDrag({
+					type: "item",
+					input: args.location.current.input,
+					source,
+					destination: context.getDropDestination(item),
 				});
 			},
 			onDrop: (args) => {
-				const source = args.source;
-				const sourceId = source.data.id;
-				if (typeof sourceId !== "string") {
+				const source = context.getItemFromDragData(args.source.data);
+				if (source === undefined) {
 					return;
 				}
 
 				onDrop({
+					type: "item",
 					input: args.location.current.input,
-					source: {
-						id: sourceId,
-						element: source.element,
-					},
+					source,
+					destination: context.getDropDestination(item),
 				});
 			},
 		});
 	});
 
 	$effect(() => {
-		return () => context.onDestroyItem(item);
+		return dropTargetForExternal({
+			element: ref!,
+			getData: () => context.getDragData(item.node.id),
+			onDragEnter: (args) => {
+				onDragEnter({
+					type: "external",
+					input: args.location.current.input,
+					items: args.source.items,
+					destination: context.getDropDestination(item),
+				});
+			},
+			onDragLeave: (args) => {
+				onDragLeave({
+					type: "external",
+					input: args.location.current.input,
+					items: args.source.items,
+					destination: context.getDropDestination(item),
+				});
+			},
+			onDrag: (args) => {
+				onDrag({
+					type: "external",
+					input: args.location.current.input,
+					items: args.source.items,
+					destination: context.getDropDestination(item),
+				});
+			},
+			onDrop: (args) => {
+				onDrop({
+					type: "external",
+					input: args.location.current.input,
+					items: args.source.items,
+					destination: context.getDropDestination(item),
+				});
+			},
+		});
+	});
+
+	$effect(() => {
+		return () => {
+			context.onDestroyItem(item);
+		};
 	});
 </script>
 

--- a/packages/svelte-file-tree/src/lib/components/context.ts
+++ b/packages/svelte-file-tree/src/lib/components/context.ts
@@ -28,9 +28,12 @@ export type TreeContext<
 	onFocusIn: (item: TreeItemState<TFile, TFolder>, event: TreeItemEvent<FocusEvent>) => void;
 	onKeyDown: (item: TreeItemState<TFile, TFolder>, event: TreeItemEvent<KeyboardEvent>) => void;
 	onClick: (item: TreeItemState<TFile, TFolder>, event: TreeItemEvent<MouseEvent>) => void;
+	getDragData: (itemId: string) => Record<string, unknown>;
+	getItemFromDragData: (data: Record<string, unknown>) => TreeItemState<TFile, TFolder> | undefined;
+	getDropDestination: (item: TreeItemState<TFile, TFolder>) => TFolder | TTree;
 	canDrag: (item: TreeItemState<TFile, TFolder>, args: ElementGetFeedbackArgs) => boolean;
-	onDragStart: (item: TreeItemState<TFile, TFolder>, args: ElementEventBasePayload) => void;
 	canDrop: (item: TreeItemState<TFile, TFolder>, args: ElementDropTargetGetFeedbackArgs) => boolean;
+	onDragStart: (item: TreeItemState<TFile, TFolder>, args: ElementEventBasePayload) => void;
 	onDestroyItem: (item: TreeItemState<TFile, TFolder>) => void;
 };
 

--- a/packages/svelte-file-tree/src/lib/components/types.ts
+++ b/packages/svelte-file-tree/src/lib/components/types.ts
@@ -38,14 +38,6 @@ export type OnChildrenChangeArgs<
 	children: Array<TFile | TFolder>;
 };
 
-export type OnDropDestinationChangeArgs<
-	TFile extends FileNode = FileNode,
-	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
-	TTree extends FileTree<TFile | TFolder> = FileTree<TFile | TFolder>,
-> = {
-	dropDestination: TFolder | TTree | undefined;
-};
-
 export type OnResolveNameConflictArgs<
 	TFile extends FileNode = FileNode,
 	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
@@ -92,6 +84,34 @@ export type OnRemoveArgs<
 	removed: Array<TreeItemState<TFile, TFolder>>;
 };
 
+export type ItemDragEventArgs<
+	TFile extends FileNode = FileNode,
+	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
+	TTree extends FileTree<TFile | TFolder> = FileTree<TFile | TFolder>,
+> = {
+	type: "item";
+	input: DragInput;
+	source: TreeItemState<TFile, TFolder>;
+	destination: TFolder | TTree;
+};
+
+export type ExternalDragEventArgs<
+	TFile extends FileNode = FileNode,
+	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
+	TTree extends FileTree<TFile | TFolder> = FileTree<TFile | TFolder>,
+> = {
+	type: "external";
+	input: DragInput;
+	items: Array<DataTransferItem>;
+	destination: TFolder | TTree;
+};
+
+export type DragEventArgs<
+	TFile extends FileNode = FileNode,
+	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
+	TTree extends FileTree<TFile | TFolder> = FileTree<TFile | TFolder>,
+> = ItemDragEventArgs<TFile, TFolder, TTree> | ExternalDragEventArgs<TFile, TFolder, TTree>;
+
 export interface TreeProps<
 	TFile extends FileNode = FileNode,
 	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
@@ -111,7 +131,6 @@ export interface TreeProps<
 	copyNode?: (node: TFile | TFolder) => TFile | TFolder;
 	onClipboardChange?: (args: OnClipboardChangeArgs) => void;
 	onChildrenChange?: (args: OnChildrenChangeArgs<TFile, TFolder, TTree>) => void;
-	onDropDestinationChange?: (args: OnDropDestinationChangeArgs<TFile, TFolder, TTree>) => void;
 	onResolveNameConflict?: (
 		args: OnResolveNameConflictArgs<TFile, TFolder, TTree>,
 	) => MaybePromise<NameConflictResolution>;
@@ -122,21 +141,16 @@ export interface TreeProps<
 	onMove?: (args: OnMoveArgs<TFile, TFolder, TTree>) => void;
 	canRemove?: (args: OnRemoveArgs<TFile, TFolder>) => MaybePromise<boolean>;
 	onRemove?: (args: OnRemoveArgs<TFile, TFolder>) => void;
+	onDragEnter?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	onDragLeave?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	onDrag?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	onDrop?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
 }
-
-export type DragSource = {
-	id: string;
-	element: HTMLElement;
-};
-
-export type DragEventArgs = {
-	input: DragInput;
-	source: DragSource;
-};
 
 export interface TreeItemProps<
 	TFile extends FileNode = FileNode,
 	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
+	TTree extends FileTree<TFile | TFolder> = FileTree<TFile | TFolder>,
 > extends Omit<
 		HTMLAttributes<HTMLDivElement>,
 		| "id"
@@ -151,10 +165,8 @@ export interface TreeItemProps<
 	children: Snippet;
 	item: TreeItemState<TFile, TFolder>;
 	ref?: HTMLElement | null;
-	onDragStart?: (args: DragEventArgs) => void;
-	onDragEnd?: (args: DragEventArgs) => void;
-	onDragEnter?: (args: DragEventArgs) => void;
-	onDragOver?: (args: DragEventArgs) => void;
-	onDragLeave?: (args: DragEventArgs) => void;
-	onDrop?: (args: DragEventArgs) => void;
+	onDragEnter?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	onDragLeave?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	onDrag?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	onDrop?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
 }

--- a/sites/preview/package.json
+++ b/sites/preview/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "vite dev --host",
 		"build": "vite build",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",

--- a/sites/preview/src/lib/components/ConfirmRemoveDialog.svelte
+++ b/sites/preview/src/lib/components/ConfirmRemoveDialog.svelte
@@ -62,7 +62,7 @@
 							</AlertDialog.Cancel>
 
 							<AlertDialog.Action
-								class="inline-flex h-10 items-center justify-center rounded bg-red-700 px-6 text-sm font-medium text-white hover:bg-red-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current active:scale-95"
+								class="inline-flex h-10 items-center justify-center rounded bg-red-700 px-6 text-sm font-medium text-white hover:bg-red-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-800 active:scale-95"
 								onclick={() => close(true)}
 							>
 								Confirm

--- a/sites/preview/src/lib/components/ResolveConflictDialog.svelte
+++ b/sites/preview/src/lib/components/ResolveConflictDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { AlertDialog } from "bits-ui";
-	import type { NameConflictResolution } from "svelte-file-tree";
 	import { fade, scale } from "svelte/transition";
+	import type { NameConflictResolution } from "svelte-file-tree";
 
 	let open = $state.raw(false);
 	let title = $state.raw("");

--- a/sites/preview/src/lib/components/Tree.svelte
+++ b/sites/preview/src/lib/components/Tree.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
+	import { flip } from "svelte/animate";
+	import { SvelteSet } from "svelte/reactivity";
 	import {
+		FileNode,
 		Tree,
+		type DragEventArgs,
 		type FileTree,
+		type FileTreeNode,
 		type FolderNode,
 		type OnChildrenChangeArgs,
 		type OnCircularReferenceArgs,
-		type OnDropDestinationChangeArgs,
 		type OnMoveArgs,
 		type OnRemoveArgs,
 		type OnResolveNameConflictArgs,
 		type TreeItemState,
 	} from "svelte-file-tree";
 	import { toast } from "svelte-sonner";
-	import { flip } from "svelte/animate";
-	import { SvelteSet } from "svelte/reactivity";
 	import ConfirmRemoveDialog from "./ConfirmRemoveDialog.svelte";
 	import ResolveConflictDialog from "./ResolveConflictDialog.svelte";
 	import TreeItem from "./TreeItem.svelte";
@@ -41,14 +43,14 @@
 		}, 1000);
 	}
 
-	function onChildrenChange(args: OnChildrenChangeArgs) {
-		if (args.operation === "insert") {
-			args.children.sort((a, b) => a.name.localeCompare(b.name));
-		}
+	function sortByName(nodes: Array<FileTreeNode>) {
+		nodes.sort((a, b) => a.name.localeCompare(b.name));
 	}
 
-	function onDropDestinationChange(args: OnDropDestinationChangeArgs) {
-		dropDestination = args.dropDestination;
+	function onChildrenChange(args: OnChildrenChangeArgs) {
+		if (args.operation === "insert") {
+			sortByName(args.children);
+		}
 	}
 
 	function onResolveNameConflict(args: OnResolveNameConflictArgs) {
@@ -93,6 +95,39 @@
 		}
 	}
 
+	function onDrag(args: DragEventArgs) {
+		dropDestination = args.destination;
+	}
+
+	function onDragLeave() {
+		dropDestination = undefined;
+	}
+
+	function onDrop(args: DragEventArgs) {
+		dropDestination = undefined;
+
+		if (args.type !== "external") {
+			return;
+		}
+
+		const files: Array<FileNode> = [];
+		for (const item of args.items) {
+			const file = item.getAsFile();
+			if (file !== null) {
+				files.push(
+					new FileNode({
+						id: crypto.randomUUID(),
+						name: file.name,
+					}),
+				);
+			}
+		}
+
+		const children = args.destination.children;
+		children.push(...files);
+		sortByName(children);
+	}
+
 	function onExpand(item: TreeItemState) {
 		expandedIds.add(item.node.id);
 	}
@@ -126,12 +161,14 @@
 		{root}
 		{expandedIds}
 		{onChildrenChange}
-		{onDropDestinationChange}
 		{onResolveNameConflict}
 		{onCircularReference}
 		{canRemove}
 		{onCopy}
 		{onMove}
+		{onDrag}
+		{onDragLeave}
+		{onDrop}
 		data-drop-destination={dropDestination === root ? true : undefined}
 		class="relative grow p-6 before:pointer-events-none before:absolute before:inset-0 before:border-2 before:border-transparent before:transition-colors focus-visible:outline-2 focus-visible:outline-current data-drop-destination:before:border-red-500"
 	>
@@ -140,6 +177,7 @@
 				<div animate:flip={{ duration: 300 }}>
 					<TreeItem
 						{item}
+						{onDragLeave}
 						{onExpand}
 						{onCollapse}
 						{onRename}

--- a/sites/preview/src/lib/components/TreeItem.svelte
+++ b/sites/preview/src/lib/components/TreeItem.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { ChevronDownIcon, FileIcon, FolderIcon, FolderOpenIcon } from "@lucide/svelte";
-	import { TreeItem } from "svelte-file-tree";
 	import type { FocusEventHandler, KeyboardEventHandler, MouseEventHandler } from "svelte/elements";
+	import { TreeItem } from "svelte-file-tree";
 	import type { TreeItemProps } from "./types.js";
 
 	const {
 		item,
 		isDropDestination,
 		isBorderAnimationTarget,
+		onDragLeave,
 		onExpand,
 		onCollapse,
 		onRename,
@@ -77,14 +78,15 @@
 
 <TreeItem
 	{item}
-	{onDragStart}
-	{onDragEnd}
+	{onDragLeave}
 	bind:ref
 	data-dragged={dragged ? true : undefined}
 	data-drop-destination={isDropDestination ? true : undefined}
 	data-animation-target={isBorderAnimationTarget ? true : undefined}
 	class="group relative flex items-center bg-white p-3 before:pointer-events-none before:absolute before:inset-0 before:border-2 before:border-transparent before:transition-colors after:pointer-events-none after:absolute after:inset-0 after:border-2 after:border-transparent after:transition-colors hover:bg-neutral-200 focus:outline-2 focus:-outline-offset-2 focus:outline-current active:bg-neutral-300 aria-selected:bg-blue-200 aria-selected:text-blue-900 aria-selected:active:bg-blue-300 data-animation-target:after:border-pink-500 data-animation-target:after:bg-pink-500/10 data-dragged:opacity-50 data-drop-destination:before:border-red-500"
 	style="padding-inline-start: calc(var(--spacing) * {item.depth * 6} + var(--spacing) * 3)"
+	ondragstart={onDragStart}
+	ondragend={onDragEnd}
 	onkeydown={onKeyDown}
 >
 	<ChevronDownIcon

--- a/sites/preview/src/lib/components/types.ts
+++ b/sites/preview/src/lib/components/types.ts
@@ -1,4 +1,4 @@
-import type { FileTree, TreeItemState } from "svelte-file-tree";
+import type { DragEventArgs, FileTree, TreeItemState } from "svelte-file-tree";
 
 export interface TreeProps {
 	root: FileTree;
@@ -8,6 +8,7 @@ export interface TreeItemProps {
 	item: TreeItemState;
 	isDropDestination: boolean;
 	isBorderAnimationTarget: boolean;
+	onDragLeave: (args: DragEventArgs) => void;
 	onExpand: (item: TreeItemState) => void;
 	onCollapse: (item: TreeItemState) => void;
 	onRename: (item: TreeItemState, name: string) => boolean;


### PR DESCRIPTION
This PR adds support for dragging and dropping files to the tree using the drag and drop callbacks. They have been reworked  to support this functionality.

Both the `<Tree>` and `<TreeItem>` components accepts four drag and drop callback props.
- `onDragEnter`
- `onDragLeave`
- `onDrag`
- `onDrop`

For the `dragstart` and `dragend` callbacks, the native events are sufficient, so no custom callback is needed.

All drag callbacks receives either of the following arguments, depending on if an item or file is being dragged.
```ts
{
  type: "item";
  input: DragInput;
  source: TreeItemState;
  destination: FolderNode | FileTree;
} | {
  type: "external";
  input: DragInput;
  items: Array<DataTransferItem>;
  destination: FolderNode | FileTree;
}
```

`onDragEnter` and `onDragLeave` are called when the dragged item or file enters or leaves the tree or an item.

`onDrag` is a repeatedly called when an item or file is being dragged over the tree or an item.

`onDrop` is called when the drag operation is finished.

`onDragEnter` and `onDragLeave` do not bubble, while `onDrag` and `onDrop` do. This means that the tree won't receive `dragenter` and `dragleave` events from tree items.