### PR TITLE
feat: add `canDrag` and `canDrop` props

### DIFF
--- a/.changeset/petite-frogs-travel.md
+++ b/.changeset/petite-frogs-travel.md
@@ -1,0 +1,5 @@
+---
+"svelte-file-tree": minor
+---
+
+feat: add `canDrag` and `canDrop` props to `Tree`

--- a/packages/svelte-file-tree/src/lib/components/context.ts
+++ b/packages/svelte-file-tree/src/lib/components/context.ts
@@ -3,6 +3,7 @@ import type {
 	ElementEventBasePayload,
 	ElementGetFeedbackArgs,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import type { ExternalDropTargetGetFeedbackArgs } from "@atlaskit/pragmatic-drag-and-drop/external/adapter";
 import { DEV } from "esm-env";
 import { getContext, hasContext, setContext } from "svelte";
 import type {
@@ -28,11 +29,16 @@ export type TreeContext<
 	onFocusIn: (item: TreeItemState<TFile, TFolder>, event: TreeItemEvent<FocusEvent>) => void;
 	onKeyDown: (item: TreeItemState<TFile, TFolder>, event: TreeItemEvent<KeyboardEvent>) => void;
 	onClick: (item: TreeItemState<TFile, TFolder>, event: TreeItemEvent<MouseEvent>) => void;
-	getDragData: (itemId: string) => Record<string, unknown>;
-	getItemFromDragData: (data: Record<string, unknown>) => TreeItemState<TFile, TFolder> | undefined;
 	getDropDestination: (item: TreeItemState<TFile, TFolder>) => TFolder | TTree;
 	canDrag: (item: TreeItemState<TFile, TFolder>, args: ElementGetFeedbackArgs) => boolean;
-	canDrop: (item: TreeItemState<TFile, TFolder>, args: ElementDropTargetGetFeedbackArgs) => boolean;
+	canDropElement: (
+		item: TreeItemState<TFile, TFolder>,
+		args: ElementDropTargetGetFeedbackArgs,
+	) => boolean;
+	canDropExternal: (
+		item: TreeItemState<TFile, TFolder>,
+		args: ExternalDropTargetGetFeedbackArgs,
+	) => boolean;
 	onDragStart: (item: TreeItemState<TFile, TFolder>, args: ElementEventBasePayload) => void;
 	onDestroyItem: (item: TreeItemState<TFile, TFolder>) => void;
 };

--- a/packages/svelte-file-tree/src/lib/components/data.ts
+++ b/packages/svelte-file-tree/src/lib/components/data.ts
@@ -1,0 +1,10 @@
+import type { DefaultTFolder, FileNode, FolderNode, TreeItemState } from "$lib/tree.svelte.js";
+
+export class DragData<
+	TFile extends FileNode = FileNode,
+	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
+> {
+	[key: PropertyKey]: unknown;
+
+	constructor(readonly item: () => TreeItemState<TFile, TFolder>) {}
+}

--- a/packages/svelte-file-tree/src/lib/components/types.ts
+++ b/packages/svelte-file-tree/src/lib/components/types.ts
@@ -84,6 +84,14 @@ export type OnRemoveArgs<
 	removed: Array<TreeItemState<TFile, TFolder>>;
 };
 
+export type CanDragArgs<
+	TFile extends FileNode = FileNode,
+	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
+> = {
+	input: DragInput;
+	source: TreeItemState<TFile, TFolder>;
+};
+
 export type ItemDragEventArgs<
 	TFile extends FileNode = FileNode,
 	TFolder extends FolderNode<TFile | TFolder> = DefaultTFolder<TFile>,
@@ -145,7 +153,9 @@ export interface TreeProps<
 	onRemove?: (args: OnRemoveArgs<TFile, TFolder>) => void;
 	onDragEnter?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
 	onDragLeave?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	canDrag?: (args: CanDragArgs<TFile, TFolder>) => boolean;
 	onDrag?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
+	canDrop?: (args: DragEventArgs<TFile, TFolder, TTree>) => boolean;
 	onDrop?: (args: DragEventArgs<TFile, TFolder, TTree>) => void;
 }
 


### PR DESCRIPTION
This PR adds two new props to the `Tree` component.

# `canDrag`

`canDrag` is a function that takes in the following object as an argument and returns a boolean:
```ts
type CanDragArgs = {
    // An object containing event properties like `clientX` and `ctrlKey`.
    input: DragInput; 
    // The item being dragged.
    source: TreeItemState;
}
```

# `canDrop`

`canDrop` is a function that takes in the following object as an argument and returns a boolean:
```ts
type DragEventArgs = {
    // The type of object being dragged. "external" usually means files. 
    type: "item" | "external";
    // An object containing event properties like `clientX` and `ctrlKey`.
    input: DragInput; 
    // The tree item being dragged, if `type` is "item".
    source: TreeItemState;
    // The external items being dragged, if `type` is "external".
    items: Array<DataTransferItem>;
    // The folder or tree being dropped on.
    dropDestination: FolderNode | FileTree;
}
```