### PR TITLE
breaking: preserve clipboard after copy

### DIFF
--- a/packages/svelte-file-tree/src/lib/components/Tree.svelte
+++ b/packages/svelte-file-tree/src/lib/components/Tree.svelte
@@ -94,6 +94,7 @@
 				}
 			}
 		},
+		shouldClearClipboard = (operation) => operation === "cut",
 		onResolveNameConflict = () => "cancel",
 		onCircularReference = noop,
 		canCopy = truePredicate,
@@ -429,7 +430,11 @@
 	}
 
 	export async function paste(destination?: TreeItemState<TFile, TFolder>) {
-		let didPaste = false;
+		if (pasteOperation === undefined) {
+			return false;
+		}
+
+		let didPaste;
 		switch (pasteOperation) {
 			case "copy": {
 				didPaste = await copy(destination);
@@ -445,8 +450,11 @@
 			return false;
 		}
 
-		clipboardIds.clear();
-		pasteOperation = undefined;
+		if (shouldClearClipboard(pasteOperation)) {
+			clipboardIds.clear();
+			pasteOperation = undefined;
+		}
+
 		return true;
 	}
 

--- a/packages/svelte-file-tree/src/lib/components/types.ts
+++ b/packages/svelte-file-tree/src/lib/components/types.ts
@@ -82,6 +82,7 @@ export interface TreeProps<
 	isItemDisabled?: (node: TFile | TFolder) => boolean;
 	isItemHidden?: (node: TFile | TFolder) => boolean;
 	copyNode?: (node: TFile | TFolder) => TFile | TFolder;
+	shouldClearClipboard?: (operation: PasteOperation) => boolean;
 	onResolveNameConflict?: (
 		args: OnResolveNameConflictArgs<TFile, TFolder>,
 	) => MaybePromise<NameConflictResolution>;


### PR DESCRIPTION
This behavior can be configured using the `shouldClearClipboard` prop.

```jsx
// this is the default value
<Tree shouldClearClipboard={(operation) => operation === "cut"} />
```